### PR TITLE
Small workaround using OMXPlayer

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -381,6 +381,11 @@ def get_global_setting(key):
     return result.get('result', {}).get('value')
 
 
+def set_global_setting(key, value):
+    """Set a Kodi setting"""
+    return jsonrpc(method='Settings.SetSettingValue', params=dict(setting=key, value=value))
+
+
 def get_cond_visibility(condition):
     """Test a condition in XBMC"""
     return xbmc.getCondVisibility(condition)

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -35,6 +35,12 @@ class Player:
         """ Play the requested item.
         :type item: string
         """
+
+        # Workaround for Raspberry Pi 3 and older
+        omxplayer = kodiutils.get_global_setting('videoplayer.useomxplayer')
+        if omxplayer is False:
+            kodiutils.set_global_setting('videoplayer.useomxplayer', True)
+
         try:
             # Check if we have credentials
             if not kodiutils.get_setting('username') or not kodiutils.get_setting('password'):


### PR DESCRIPTION
This is a workaround that improves playback on Raspberry Pi and older  on Kodi v18 and older.

This works on Raspberry Pi, needs to be tested on RPi4 and non-RPi.

This relates to #4 