### PR TITLE
Rework cache

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -177,8 +177,3 @@ msgstr ""
 msgctxt "#30831"
 msgid "Update local metadata now"
 msgstr ""
-
-msgctxt "#30833"
-msgid "Clear local metadata"
-msgstr ""
-

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -178,7 +178,3 @@ msgstr "Vernieuw de lokale metdata automatisch in de achtergrond"
 msgctxt "#30831"
 msgid "Update local metadata now"
 msgstr "De lokale metadata nu vernieuwen"
-
-msgctxt "#30833"
-msgid "Clear local metadata"
-msgstr "De lokale metadata verwijderen"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -111,13 +111,6 @@ def metadata_update():
     Metadata().update()
 
 
-@routing.route('/metadata/clean')
-def metadata_clean():
-    """ Clear metadata (called from settings) """
-    from resources.lib.modules.metadata import Metadata
-    Metadata().clean()
-
-
 def run(params):
     """ Run the routing plugin """
     routing.run(params)

--- a/resources/lib/modules/catalog.py
+++ b/resources/lib/modules/catalog.py
@@ -20,8 +20,8 @@ class Catalog:
 
     def __init__(self):
         """ Initialise object """
-        auth = AuthApi(kodiutils.get_setting('username'), kodiutils.get_setting('password'))
-        self._api = ContentApi(auth)
+        auth = AuthApi(kodiutils.get_setting('username'), kodiutils.get_setting('password'), kodiutils.get_tokens_path())
+        self._api = ContentApi(auth, cache_path=kodiutils.get_cache_path())
         self._menu = Menu()
 
     def show_catalog(self):

--- a/resources/lib/modules/metadata.py
+++ b/resources/lib/modules/metadata.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 from resources.lib import kodiutils
 from resources.lib.viervijfzes import CHANNELS
-from resources.lib.viervijfzes.content import ContentApi, Program, CACHE_PREVENT, CACHE_ONLY
+from resources.lib.viervijfzes.content import ContentApi, Program, CACHE_PREVENT, CACHE_AUTO
 
 
 class Metadata:
@@ -33,6 +33,7 @@ class Metadata:
     def fetch_metadata(self, callback=None, refresh=False):
         """ Fetch the metadata for all the items in the catalog
         :type callback: callable
+        :type refresh: bool
         """
         # Fetch all items from the catalog
         items = []
@@ -43,7 +44,7 @@ class Metadata:
         # Loop over all of them and download the metadata
         for index, item in enumerate(items):
             if isinstance(item, Program):
-                self._api.get_program(item.channel, item.path, CACHE_PREVENT if refresh else CACHE_ONLY)
+                self._api.get_program(item.channel, item.path, CACHE_PREVENT if refresh else CACHE_AUTO)
 
             # Run callback after every item
             if callback and callback(index, count):

--- a/resources/lib/modules/metadata.py
+++ b/resources/lib/modules/metadata.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 from resources.lib import kodiutils
 from resources.lib.viervijfzes import CHANNELS
-from resources.lib.viervijfzes.content import ContentApi, Program
+from resources.lib.viervijfzes.content import ContentApi, Program, CACHE_PREVENT, CACHE_ONLY
 
 
 class Metadata:
@@ -13,7 +13,7 @@ class Metadata:
 
     def __init__(self):
         """ Initialise object """
-        self._api = ContentApi()
+        self._api = ContentApi(cache_path=kodiutils.get_cache_path())
 
     def update(self):
         """ Update the metadata with a foreground progress indicator """
@@ -25,25 +25,25 @@ class Metadata:
             progress.update(int(((i + 1) / total) * 100), kodiutils.localize(30716, index=i + 1, total=total))  # Updating metadata ({index}/{total})
             return progress.iscanceled()
 
-        self.fetch_metadata(callback=update_status)
+        self.fetch_metadata(callback=update_status, refresh=True)
 
         # Close progress indicator
         progress.close()
 
-    def fetch_metadata(self, callback=None):
+    def fetch_metadata(self, callback=None, refresh=False):
         """ Fetch the metadata for all the items in the catalog
         :type callback: callable
         """
         # Fetch all items from the catalog
         items = []
         for channel in list(CHANNELS):
-            items.extend(self._api.get_programs(channel))
+            items.extend(self._api.get_programs(channel, CACHE_PREVENT))
         count = len(items)
 
         # Loop over all of them and download the metadata
         for index, item in enumerate(items):
             if isinstance(item, Program):
-                self._api.get_program(item.channel, item.path)
+                self._api.get_program(item.channel, item.path, CACHE_PREVENT if refresh else CACHE_ONLY)
 
             # Run callback after every item
             if callback and callback(index, count):
@@ -51,10 +51,3 @@ class Metadata:
                 return False
 
         return True
-
-    @staticmethod
-    def clean():
-        """ Clear metadata (called from settings) """
-        kodiutils.invalidate_cache()
-        kodiutils.set_setting('metadata_last_updated', '0')
-        kodiutils.ok_dialog(message=kodiutils.localize(30714))  # Local metadata is cleared

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -53,7 +53,7 @@ class Player:
 
             # Fetch an auth token now
             try:
-                auth = AuthApi(kodiutils.get_setting('username'), kodiutils.get_setting('password'))
+                auth = AuthApi(kodiutils.get_setting('username'), kodiutils.get_setting('password'), kodiutils.get_tokens_path())
 
                 # Get stream information
                 resolved_stream = ContentApi(auth).get_stream_by_uuid(item)

--- a/resources/lib/viervijfzes/auth.py
+++ b/resources/lib/viervijfzes/auth.py
@@ -86,7 +86,8 @@ class AuthApi:
 
     def clear_tokens(self):
         """ Remove the cached tokens. """
-        os.unlink(self._token_path + AuthApi.TOKEN_FILE)
+        if os.path.exists(self._token_path + AuthApi.TOKEN_FILE):
+            os.unlink(self._token_path + AuthApi.TOKEN_FILE)
 
     @staticmethod
     def _authenticate(username, password):

--- a/resources/lib/viervijfzes/auth.py
+++ b/resources/lib/viervijfzes/auth.py
@@ -5,9 +5,9 @@ from __future__ import absolute_import, division, unicode_literals
 
 import json
 import logging
+import os
 import time
 
-from resources.lib import kodiutils
 from resources.lib.viervijfzes.auth_awsidp import AwsIdp, InvalidLoginException, AuthenticationException
 
 _LOGGER = logging.getLogger('auth-api')
@@ -21,18 +21,18 @@ class AuthApi:
 
     TOKEN_FILE = 'auth-tokens.json'
 
-    def __init__(self, username, password):
+    def __init__(self, username, password, token_path):
         """ Initialise object """
         self._username = username
         self._password = password
-        self._cache_dir = kodiutils.get_tokens_path()
+        self._token_path = token_path
         self._id_token = None
         self._expiry = 0
         self._refresh_token = None
 
         # Load tokens from cache
         try:
-            with kodiutils.open_file(self._cache_dir + self.TOKEN_FILE, 'rb') as fdesc:
+            with open(self._token_path + self.TOKEN_FILE, 'rb') as fdesc:
                 data_json = json.loads(fdesc.read())
                 self._id_token = data_json.get('id_token')
                 self._refresh_token = data_json.get('refresh_token')
@@ -72,9 +72,9 @@ class AuthApi:
             self._expiry = now + 3600
 
         # Store new tokens in cache
-        if not kodiutils.exists(self._cache_dir):
-            kodiutils.mkdirs(self._cache_dir)
-        with kodiutils.open_file(self._cache_dir + self.TOKEN_FILE, 'wb') as fdesc:
+        if not os.path.exists(self._token_path):
+            os.mkdir(self._token_path)
+        with open(self._token_path + self.TOKEN_FILE, 'wb') as fdesc:
             data = json.dumps(dict(
                 id_token=self._id_token,
                 refresh_token=self._refresh_token,
@@ -84,10 +84,9 @@ class AuthApi:
 
         return self._id_token
 
-    @staticmethod
-    def clear_tokens():
+    def clear_tokens(self):
         """ Remove the cached tokens. """
-        kodiutils.delete(kodiutils.get_tokens_path() + AuthApi.TOKEN_FILE)
+        os.unlink(self._token_path + AuthApi.TOKEN_FILE)
 
     @staticmethod
     def _authenticate(username, password):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,5 @@
         <setting label="30827" type="lsep"/> <!-- Metadata -->
         <setting label="30829" type="bool" id="metadata_update" default="true" subsetting="true"/>
         <setting label="30831" type="action" action="RunPlugin(plugin://plugin.video.viervijfzes/metadata/update)"/>
-        <setting label="30833" type="action" action="RunPlugin(plugin://plugin.video.viervijfzes/metadata/clean)"/>
     </category>
 </settings>

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -18,8 +18,8 @@ _LOGGER = logging.getLogger('test-api')
 class TestApi(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestApi, self).__init__(*args, **kwargs)
-        auth = AuthApi(kodiutils.get_setting('username'), kodiutils.get_setting('password'))
-        self._api = ContentApi(auth)
+        auth = AuthApi(kodiutils.get_setting('username'), kodiutils.get_setting('password'), kodiutils.get_tokens_path())
+        self._api = ContentApi(auth, cache_path=kodiutils.get_cache_path())
 
     def test_programs(self):
         for channel in ['vier', 'vijf', 'zes']:
@@ -39,9 +39,6 @@ class TestApi(unittest.TestCase):
     def test_get_stream(self):
         program = self._api.get_program('vier', 'auwch')
         self.assertIsInstance(program, Program)
-
-        program_by_uuid = self._api.get_program_by_uuid(program.uuid)
-        self.assertIsInstance(program_by_uuid, Program)
 
         episode = program.episodes[0]
         video = self._api.get_stream_by_uuid(episode.uuid)

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -20,16 +20,16 @@ class TestAuth(unittest.TestCase):
 
     @unittest.skipUnless(kodiutils.get_setting('username') and kodiutils.get_setting('password'), 'Skipping since we have no credentials.')
     def test_login(self):
+        auth = AuthApi(kodiutils.get_setting('username'), kodiutils.get_setting('password'), kodiutils.get_tokens_path())
+
         # Clear any cache we have
-        AuthApi.clear_tokens()
+        auth.clear_tokens()
 
         # We should get a token by logging in
-        auth = AuthApi(kodiutils.get_setting('username'), kodiutils.get_setting('password'))
         token = auth.get_token()
         self.assertTrue(token)
 
         # Test it a second time, it should go from memory now
-        auth = AuthApi(kodiutils.get_setting('username'), kodiutils.get_setting('password'))
         token = auth.get_token()
         self.assertTrue(token)
 

--- a/test/test_epg.py
+++ b/test/test_epg.py
@@ -9,6 +9,7 @@ import logging
 import unittest
 from datetime import date
 
+from resources.lib import kodiutils
 from resources.lib.viervijfzes.content import ContentApi, Episode
 from resources.lib.viervijfzes.epg import EpgApi, EpgProgram
 
@@ -48,7 +49,7 @@ class TestEpg(unittest.TestCase):
         epg_program = [program for program in epg_programs if program.video_url][0]
 
         # Lookup the Episode data since we don't have an UUID
-        api = ContentApi()
+        api = ContentApi(cache_path=kodiutils.get_cache_path())
         episode = api.get_episode(epg_program.channel, epg_program.video_url)
         self.assertIsInstance(episode, Episode)
 

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -57,7 +57,7 @@ class TestRouting(unittest.TestCase):
         routing.run([routing.url_for(addon.show_tvguide_detail, channel='vier', date='today'), '0', ''])
 
     def test_metadata_update(self):
-        routing.run([routing.url_for(addon.metadata_clean), '0', ''])
+        routing.run([routing.url_for(addon.metadata_update), '0', ''])
 
 
 if __name__ == '__main__':

--- a/test/xbmcgui.py
+++ b/test/xbmcgui.py
@@ -129,9 +129,9 @@ class DialogProgress:
         print('\033[37;44;1mPROGRESS:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, line1))
         sys.stdout.flush()
 
-    @staticmethod
-    def iscanceled():
+    def iscanceled(self):
         """A stub implementation for the xbmcgui DialogProgress class iscanceled() method"""
+        return self.percentage > 5  # Cancel at 5%
 
     def update(self, percentage, line1=None, line2=None, line3=None):
         """A stub implementation for the xbmcgui DialogProgress class update() method"""


### PR DESCRIPTION
* Caches program listings.
* Remove "Clear local metadata" option, since "Refresh local metadata" force refreshes everything anyway.
* Allows to fallback on expired cache when fetching data fails.
* Don't use xbmcvfs, but use standard python `os` methods.
* Make set_cache responsible for the ttl by changing the modified time.