### PR TITLE
Fix multi-line text in progress dialog

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -264,13 +264,17 @@ class progress(xbmcgui.DialogProgress, object):  # pylint: disable=invalid-name,
     def create(self, heading, message=''):  # pylint: disable=arguments-differ
         """Create and show a progress dialog"""
         if kodi_version_major() < 19:
-            return super(progress, self).create(heading, line1=message)
+            lines = message.split('\n', 2)
+            line1, line2, line3 = (lines + [None] * (3-len(lines)))
+            return super(progress, self).create(heading, line1=line1, line2=line2, line3=line3)
         return super(progress, self).create(heading, message=message)
 
     def update(self, percent, message=''):  # pylint: disable=arguments-differ
         """Update the progress dialog"""
         if kodi_version_major() < 19:
-            return super(progress, self).update(percent, line1=message)
+            lines = message.split('\n', 2)
+            line1, line2, line3 = (lines + [None] * (3-len(lines)))
+            return super(progress, self).update(percent, line1=line1, line2=line2, line3=line3)
         return super(progress, self).update(percent, message=message)
 
 


### PR DESCRIPTION
I introduced a bug in https://github.com/add-ons/plugin.video.viervijfzes/commit/2df7282d7eb386e600123af8b7506dfd93f6e03e
In some specific cases the progress dialog would show duplicate lines. This pull request fixes this.