### PR TITLE
AttributeError: 'list' object has no attribute 'get'

### DIFF
--- a/resources/lib/viervijfzes/content.py
+++ b/resources/lib/viervijfzes/content.py
@@ -539,7 +539,7 @@ class ContentApi:
             nodeid=data.get('pageInfo', {}).get('nodeId'),
             path=data.get('link').lstrip('/'),
             channel=data.get('pageInfo', {}).get('site'),
-            program_title=data.get('program', {}).get('title'),
+            program_title=data.get('program', {}).get('title') if data.get('program') else data.get('title'),
             title=data.get('title'),
             description=data.get('pageInfo', {}).get('description'),
             cover=data.get('image'),


### PR DESCRIPTION
This fixes the following error because in some cases the "program" key
contains an empty list, rather than a dictionary.

```
2020-10-26 02:22:27.306 T:1438569344   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.AttributeError'>
                                            Error Contents: 'list' object has no attribute 'get'
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.viervijfzes/addon_entry.py", line 18, in <module>
                                                run(argv)
                                              File "/storage/.kodi/addons/plugin.video.viervijfzes/resources/lib/addon.py", line 172, in run
                                                routing.run(params)
                                              File "/storage/.kodi/addons/script.module.routing/lib/routing.py", line 130, in run
                                                self._dispatch(self.path)
                                              File "/storage/.kodi/addons/script.module.routing/lib/routing.py", line 141, in _dispatch
                                                view_func(**kwargs)
                                              File "/storage/.kodi/addons/plugin.video.viervijfzes/resources/lib/addon.py", line 70, in show_catalog
                                                Catalog().show_catalog()
                                              File "/storage/.kodi/addons/plugin.video.viervijfzes/resources/lib/modules/catalog.py", line 31, in show_catalog
                                                items.extend(self._api.get_programs(channel))
                                              File "/storage/.kodi/addons/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py", line 216, in get_programs
                                                program = self.get_program(channel, path, cache=CACHE_ONLY)  # Get program details, but from cache only
                                              File "/storage/.kodi/addons/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py", line 262, in get_program
                                                program = self._parse_program_data(data)
                                              File "/storage/.kodi/addons/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py", line 514, in _parse_program_data
                                                for episode in playlist['episodes']
                                              File "/storage/.kodi/addons/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py", line 542, in _parse_episode_data
                                                program_title=data.get('program', {}).get('title'),
                                            AttributeError: 'list' object has no attribute 'get'
                                            -->End of Python script error report<--
2020-10-26 02:22:27.710 T:915403648   ERROR: GetDirectory - Error getting plugin://plugin.video.viervijfzes/catalog
2020-10-26 02:22:27.717 T:1937566144   ERROR: CGUIMediaWindow::GetDirectory(plugin://plugin.video.viervijfzes/catalog) failed
```