### PR TITLE
Fix EPG due to parsing issue of the season

### DIFF
--- a/resources/lib/modules/iptvmanager.py
+++ b/resources/lib/modules/iptvmanager.py
@@ -80,7 +80,7 @@ class IPTVManager:
                         title=program.program_title,
                         subtitle=program.episode_title,
                         description=program.description,
-                        episode='S%dE%d' % (program.season, program.number) if program.season and program.number else None,
+                        episode='S%sE%s' % (program.season, program.number) if program.season and program.number else None,
                         genre=program.genre,
                         genre_id=program.genre_id,
                         image=program.cover,

--- a/resources/lib/viervijfzes/epg.py
+++ b/resources/lib/viervijfzes/epg.py
@@ -138,7 +138,7 @@ class EpgApi:
             episode_title=data.get('episode_title'),
             episode_title_original=data.get('original_title'),
             number=int(data.get('episode_nr')) if data.get('episode_nr') else None,
-            season=int(data.get('season')) if data.get('season') else None,
+            season=data.get('season'),
             genre=data.get('genre'),
             start=start,
             won_id=int(data.get('won_id')) if data.get('won_id') else None,


### PR DESCRIPTION
It seems that `season` can also contain something like `2020-2021`, what isn't an `int` and causes the parsing of the EPG to fail.