### PR TITLE
Fix authentication on some older Android devices

### DIFF
--- a/resources/lib/viervijfzes/auth_awsidp.py
+++ b/resources/lib/viervijfzes/auth_awsidp.py
@@ -12,7 +12,6 @@ import hmac
 import json
 import logging
 import os
-import sys
 
 import requests
 import six
@@ -340,11 +339,7 @@ class AwsIdp:
         days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
         time_now = datetime.datetime.utcnow()
-        if sys.platform.startswith('win'):
-            format_string = "{} {} %#d %H:%M:%S UTC %Y".format(days[time_now.weekday()], months[time_now.month])
-        else:
-            format_string = "{} {} %-d %H:%M:%S UTC %Y".format(days[time_now.weekday()], months[time_now.month])
-
+        format_string = "{} {} {} %H:%M:%S UTC %Y".format(days[time_now.weekday()], months[time_now.month], time_now.day)
         time_string = datetime.datetime.utcnow().strftime(format_string)
         return time_string
 


### PR DESCRIPTION
It seems that some older Android devices don't understand the `%-d` syntax of `strftime`, so modifying the date-portion to use the date directly instead of relying on strftime helps fix this issue.

This has been reported on a `Android 7.1.2 API level 25, kernel: Linux ARM 32-bit version 3.14.29`

Fixes #41 