### PR TITLE
Make use of git archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,7 @@ ifdef release
 else
 	zip_name = $(name)-$(version)-$(git_branch)-$(git_hash).zip
 endif
-
-include_files = addon_entry.py addon.xml CHANGELOG.md LICENSE README.md resources/ service_entry.py
-include_paths = $(patsubst %,$(name)/%,$(include_files))
-exclude_files = \*.new \*.orig \*.pyc \*.pyo
+zip_dir = $(name)/
 
 languages = $(filter-out en_gb, $(patsubst resources/language/resource.language.%, %, $(wildcard resources/language/*)))
 
@@ -27,22 +24,22 @@ zip: build
 check: check-pylint check-tox check-translations
 
 check-pylint:
-	@echo ">>> Running pylint checks"
+	@printf ">>> Running pylint checks\n"
 	@$(PYTHON) -m pylint *.py resources/lib/ tests/
 
 check-tox:
-	@echo ">>> Running tox checks"
+	@printf ">>> Running tox checks\n"
 	@$(PYTHON) -m tox -q
 
 check-translations:
-	@echo ">>> Running translation checks"
+	@printf ">>> Running translation checks\n"
 	@$(foreach lang,$(languages), \
 		msgcmp resources/language/resource.language.$(lang)/strings.po resources/language/resource.language.en_gb/strings.po; \
 	)
 	@tests/check_for_unused_translations.py
 
 check-addon: clean build
-	@echo ">>> Running addon checks"
+	@printf ">>> Running addon checks\n"
 	$(eval TMPDIR := $(shell mktemp -d))
 	@unzip ../${zip_name} -d ${TMPDIR}
 	cd ${TMPDIR} && kodi-addon-checker --branch=leia
@@ -54,43 +51,44 @@ codefix:
 test: test-unit
 
 test-unit:
-	@echo ">>> Running unit tests"
+	@printf ">>> Running unit tests\n"
 	@$(PYTHON) -m pytest tests
 
 clean:
+	@printf ">>> Cleaning up\n"
 	@find . -name '*.py[cod]' -type f -delete
 	@find . -name '__pycache__' -type d -delete
 	@rm -rf .pytest_cache/ .tox/ tests/cdm tests/userdata/temp
 	@rm -f *.log .coverage
 
 build: clean
-	@echo ">>> Building package"
+	@printf ">>> Building package\n"
 	@rm -f ../$(zip_name)
-	cd ..; zip -r $(zip_name) $(include_paths) -x $(exclude_files)
-	@echo "Successfully wrote package as: ../$(zip_name)"
+	@git archive --format zip --worktree-attributes -v -o ../$(zip_name) --prefix $(zip_dir) $(or $(shell git stash create), HEAD)
+	@printf ">>> Successfully wrote package as: ../$(zip_name)\n"
 
 # You first need to run sudo gem install github_changelog_generator for this
 release:
 ifneq ($(release),)
-	@github_changelog_generator -u add-ons -p plugin.video.viervijfzes --no-issues --exclude-labels duplicate,question,invalid,wontfix release --future-release v$(release);
+	@github_changelog_generator -u add-ons -p $(name) --no-issues --exclude-labels duplicate,question,invalid,wontfix release --future-release v$(release);
 
-	@echo "cd /addon/@version\nset $$release\nsave\nbye" | xmllint --shell addon.xml; \
+	@printf "cd /addon/@version\nset $$release\nsave\nbye\n" | xmllint --shell addon.xml; \
 	date=$(shell date '+%Y-%m-%d'); \
-	echo "cd /addon/extension[@point='xbmc.addon.metadata']/news\nset v$$release ($$date)\nsave\nbye" | xmllint --shell addon.xml; \
+	printf "cd /addon/extension[@point='xbmc.addon.metadata']/news\nset v$$release ($$date)\nsave\nbye\n" | xmllint --shell addon.xml; \
 
 	# Next steps to release:
 	# - Modify the news-section of addons.xml
 	# - git add . && git commit -m "Prepare for v$(release)" && git push
 	# - git tag v$(release) && git push --tags
 else
-	@echo "Usage: make release release=1.0.0"
+	@printf "Usage: make release release=1.0.0\n"
 endif
 
 multizip: clean
 	@-$(foreach abi,$(KODI_PYTHON_ABIS), \
-		echo "cd /addon/requires/import[@addon='xbmc.python']/@version\nset $(abi)\nsave\nbye" | xmllint --shell addon.xml; \
+		printf "cd /addon/requires/import[@addon='xbmc.python']/@version\nset $(abi)\nsave\nbye\n" | xmllint --shell addon.xml; \
 		matrix=$(findstring $(abi), $(word 1,$(KODI_PYTHON_ABIS))); \
 		if [ $$matrix ]; then version=$(version)+matrix.1; else version=$(version); fi; \
-		echo "cd /addon/@version\nset $$version\nsave\nbye" | xmllint --shell addon.xml; \
+		printf "cd /addon/@version\nset $$version\nsave\nbye\n" | xmllint --shell addon.xml; \
 		make build; \
 	)


### PR DESCRIPTION
This simplifies the creation of the ZIP file as it uses .gitattributes for excluding common files.

It builds a ZIP file based on the working directory by using the current working directory as a stash.