### PR TITLE
Don't use cached episode info for playback

### DIFF
--- a/resources/lib/modules/menu.py
+++ b/resources/lib/modules/menu.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
+import logging
+
 from resources.lib import kodiutils
 from resources.lib.kodiutils import TitleItem
 from resources.lib.viervijfzes import STREAM_DICT
@@ -12,6 +14,8 @@ try:  # Python 3
     from urllib.parse import quote
 except ImportError:  # Python 2
     from urllib import quote
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Menu:
@@ -184,13 +188,12 @@ class Menu:
                 'duration': item.duration,
             })
 
-            if item.path:
+            if item.uuid:
+                # We have an UUID and can play this item directly
+                path = kodiutils.url_for('play_catalog', uuid=item.uuid)
+            else:
                 # We don't have an UUID, and first need to fetch the video information from the page
                 path = kodiutils.url_for('play_from_page', page=quote(item.path, safe=''))
-            else:
-                # We have an UUID and can play this item directly
-                # This is not preferred since we will lack metadata
-                path = kodiutils.url_for('play_catalog', uuid=item.uuid)
 
             return TitleItem(title=info_dict['title'],
                              path=path,

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -10,7 +10,7 @@ from resources.lib.modules.menu import Menu
 from resources.lib.viervijfzes import CHANNELS, ResolvedStream
 from resources.lib.viervijfzes.auth import AuthApi
 from resources.lib.viervijfzes.aws.cognito_idp import AuthenticationException, InvalidLoginException
-from resources.lib.viervijfzes.content import ContentApi, GeoblockedException, UnavailableException
+from resources.lib.viervijfzes.content import CACHE_PREVENT, ContentApi, GeoblockedException, UnavailableException
 
 try:  # Python 3
     from urllib.parse import quote, urlencode
@@ -45,7 +45,7 @@ class Player:
         :type path: string
         """
         # Get episode information
-        episode = self._api.get_episode(path)
+        episode = self._api.get_episode(path, cache=CACHE_PREVENT)
         resolved_stream = None
 
         if episode is None:


### PR DESCRIPTION
* Don't use cached episode info for playback.
* Prefer playback by uuid instead of scraping the page.

I think this fixes issue #81 