### PR TITLE
Use inputstreamhelper for unprotected MPEG-DASH

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -259,12 +259,17 @@ def play(stream, stream_type=STREAM_HLS, license_key=None, title=None, art_dict=
     elif stream_type == STREAM_DASH:
         play_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
         play_item.setMimeType('application/dash+xml')
+        import inputstreamhelper
         if license_key is not None:
-            import inputstreamhelper
+            # DRM protected MPEG-DASH
             is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
             if is_helper.check_inputstream():
                 play_item.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
                 play_item.setProperty('inputstream.adaptive.license_key', license_key)
+        else:
+            # Unprotected MPEG-DASH
+            is_helper = inputstreamhelper.Helper('mpd')
+            is_helper.check_inputstream()
 
     play_item.setContentLookup(False)
 


### PR DESCRIPTION
It seems InputStream Adaptive add-on is missing on newly installed Kodi systems.
We need this add-on for playing all MPEG-DASH streams.
This fix adds auto install for InputStream Adaptive add-on for unprotected MPEG-DASH streams using inputstreamhelper.