### PR TITLE
Drop testing for Python 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,11 @@ jobs:
         include:
           # End-of-life Python versions are not available anymore with ubuntu-latest
           - os: ubuntu-20.04
-            python-version: "2.7"
-          - os: ubuntu-20.04
             python-version: "3.5"
           - os: ubuntu-20.04
             python-version: "3.6"
           - os: ubuntu-20.04
             python-version: "3.7"
-          # Kodi Leia on Windows uses a bundled Python 2.7.
-          - os: windows-latest
-            python-version: "2.7"
     steps:
       - name: Check out ${{ github.sha }} from repository ${{ github.repository }}
         uses: actions/checkout@v3

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -5,10 +5,8 @@ from __future__ import absolute_import, division, unicode_literals
 
 import os
 import shutil
-import sys
 import xml.etree.ElementTree as ET
 
-BRANDS_DIR = 'brands'
 DIST_DIR = 'dist'
 
 
@@ -85,5 +83,5 @@ if __name__ == '__main__':
     shutil.make_archive(os.path.join(DIST_DIR, "%s-%s+matrix.1" % (brand, addon_info['version'])), 'zip', DIST_DIR, brand)
 
     # Modify addon.xml for leia and create zip
-    modify_xml(os.path.join(dest, 'addon.xml'), addon_info['version'], addon_info['news'], '2.26.0')
-    shutil.make_archive(os.path.join(DIST_DIR, "%s-%s" % (brand, addon_info['version'])), 'zip', DIST_DIR, brand)
+    # modify_xml(os.path.join(dest, 'addon.xml'), addon_info['version'], addon_info['news'], '2.26.0')
+    # shutil.make_archive(os.path.join(DIST_DIR, "%s-%s" % (brand, addon_info['version'])), 'zip', DIST_DIR, brand)


### PR DESCRIPTION
Github actions isn't supporting 2.7 anymore, it's time we move on.